### PR TITLE
Fix README install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ templates/
 1. Clone the repository:
    ```bash
    git clone https://github.com/m3d4r-commits/LLM-Compare
-   cd llm-webapp
+   cd LLM-Compare
    ```
 
 2. Create a virtual environment and activate it:


### PR DESCRIPTION
## Summary
- fix README directions to use the repo name `LLM-Compare`

## Testing
- `pytest -q`
- `python -m py_compile askllm.py`


------
https://chatgpt.com/codex/tasks/task_e_68400cfdb2fc8323913a5e60eaad11f0