### PR TITLE
Add timeout to DeepSeek request

### DIFF
--- a/askllm.py
+++ b/askllm.py
@@ -56,7 +56,12 @@ def query_llm_3(question):
                 {"role": "user", "content": question}
             ]
         }
-        response = requests.post("https://api.deepseek.com/v1/chat/completions", json=payload, headers=headers)
+        response = requests.post(
+            "https://api.deepseek.com/v1/chat/completions",
+            json=payload,
+            headers=headers,
+            timeout=30,
+        )
         response.raise_for_status()
         return response.json()["choices"][0]["message"]["content"]
     except Exception as e:


### PR DESCRIPTION
## Summary
- set a 30-second timeout for the DeepSeek API POST request in `query_llm_3`

## Testing
- `python -m py_compile askllm.py`


------
https://chatgpt.com/codex/tasks/task_e_68400e8389988323a9faf0024c00fa8d